### PR TITLE
Fix czi file download URL for tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bftools
 Title: BioFormats Tools
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: 
     person(given = "John",
            family = "Muschelli",
@@ -28,4 +28,4 @@ LazyData: true
 VignetteBuilder: knitr
 URL: https://github.com/muschellij2/bftools
 BugReports: https://github.com/muschellij2/bftools/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.3.2

--- a/bftools.Rproj
+++ b/bftools.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 69cd2802-24ac-40ed-870e-8f9b57b1bf7d
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-czi.R
+++ b/tests/testthat/test-czi.R
@@ -7,7 +7,8 @@ testthat::context("Downloading CZI")
 
 options(digits = 10)
 # from https://figshare.com/articles/Fluorescence_microscopy_of_Chlamydomonas_reinhardtii_for_mCherry_detection_secretion_peptides_strains_/9114647/1
-url = "https://ndownloader.figshare.com/files/16618418"
+#url = "https://ndownloader.figshare.com/files/16618418"
+url= "https://zenodo.org/records/579617/files/pJP28mCherry.czi?download=1"
 destfile = file.path(tempdir(), "pJP28mCherry.czi")
 if (!file.exists(destfile)) {
   download.file(url, destfile = destfile)


### PR DESCRIPTION
https://ndownloader.figshare.com/files/16618418 does not work anymore
replaced with https://zenodo.org/records/579617/files/pJP28mCherry.czi?download=1